### PR TITLE
Added support for markdown-autodocs github action

### DIFF
--- a/.github/workflows/markdown-autodocs.yml
+++ b/.github/workflows/markdown-autodocs.yml
@@ -1,0 +1,14 @@
+name: markdown-autodocs
+
+on:
+  push:
+    branches:    
+      - '**'  # matches every branch
+
+jobs:        
+  auto-update-readme:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Markdown autodocs
+          uses: dineshsonachalam/markdown-autodocs@v1.0.2

--- a/README.md
+++ b/README.md
@@ -22,95 +22,23 @@
 
 ## Installation
 
-with npm:
-
-```
-npm install fireworks-js
-```
-
-or yarn:
-
-```
-yarn add fireworks-js
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/installation.sh) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Usage
 
-```js 
-// ES6
-import { Fireworks } from 'fireworks-js'
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage.js) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
-```js
-// commonjs
-const { Fireworks } = require('fireworks-js')
-```
-
-```html
-<!-- including in your html page -->
-<script src="https://unpkg.com/fireworks-js@latest/dist/fireworks.js"></script>
-```
-
-```js
-// use querySelector or getElementById
-const container = document.querySelector('.fireworks-container')
-
-// default config
-const fireworks = new Fireworks(container, {
-    // options
-})
-
-fireworks.start()
-
-fireworks.pause()
-
-fireworks.clear()
-
-// stop and clear fireworks
-fireworks.stop()
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage.html) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 For React.js (see detailed usage [here](test/react.tsx))
 
-```js
-import { Fireworks } from 'fireworks-js/dist/react'
-
-export const App = () => {
-  const options = {
-    speed: 3
-  }
-
-  const style = {
-    left: 0,
-    top: 0,
-    width: '100%',
-    height: '100%',
-    position: 'fixed',
-    background: '#000'
-  }
-
-  return <Fireworks options={options} style={style} />
-}
-```
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage-react.js) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Options
 
-key | default values
-----|---------------
-`speed` | `2`
-`acceleration` | `1.05`
-`friction` | `0.95`
-`gravity` | `1.5`
-`particles` | `50`
-`trace` | `3`
-`explosion` | `5`
-`autoresize` | `true`
-`hue` | `{ min: 0, max: 360 }`
-`delay` | `{ min: 15, max: 30 }`
-`boundaries` | `{ top: 50, bottom: container.clientHeight, left: 50, right: container.clientWidth }`
-`sound` | `{ enable: false }`
-`sound.files` | `[ '*.mp3', '*.ogg', '*.wav' ]`
-`sound.volume` | `{ min: 1, max: 2 }`
-`mouse` |`{ click: false, move: false, max: 3 }`
-`brightness` | ` { min: 50, max: 80 }`
-`brightness.decay` | `{ min: 0.015, max: 0.03 }`
+<!-- MARKDOWN-AUTO-DOCS:START (JSON_TO_HTML_TABLE:src=./examples/readme/options.json) -->
+<!-- MARKDOWN-AUTO-DOCS:END -->

--- a/README.md
+++ b/README.md
@@ -23,22 +23,98 @@
 ## Installation
 
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/installation.sh) -->
+<!-- The below code snippet is automatically added from ./examples/readme/installation.sh -->
+```sh
+# with npm:
+npm install fireworks-js
+
+# or yarn:
+yarn add fireworks-js
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Usage
 
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage.js) -->
+<!-- The below code snippet is automatically added from ./examples/readme/usage.js -->
+```js
+// ES6
+import { Fireworks } from 'fireworks-js'
+
+// commonjs
+const { Fireworks } = require('fireworks-js')
+
+// use querySelector or getElementById
+const container = document.querySelector('.fireworks-container')
+
+// default config
+const fireworks = new Fireworks(container, {
+    // options
+})
+
+fireworks.start()
+
+fireworks.pause()
+
+fireworks.clear()
+
+// stop and clear fireworks
+fireworks.stop()
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage.html) -->
+<!-- The below code snippet is automatically added from ./examples/readme/usage.html -->
+```html
+<!-- including in your html page -->
+<script src="https://unpkg.com/fireworks-js@latest/dist/fireworks.js"></script>
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 For React.js (see detailed usage [here](test/react.tsx))
 
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=./examples/readme/usage-react.js) -->
+<!-- The below code snippet is automatically added from ./examples/readme/usage-react.js -->
+```js
+import { Fireworks } from 'fireworks-js/dist/react'
+
+export const App = () => {
+  const options = {
+    speed: 3
+  }
+
+  const style = {
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+    position: 'fixed',
+    background: '#000'
+  }
+
+  return <Fireworks options={options} style={style} />
+}
+```
 <!-- MARKDOWN-AUTO-DOCS:END -->
 
 ## Options
 
 <!-- MARKDOWN-AUTO-DOCS:START (JSON_TO_HTML_TABLE:src=./examples/readme/options.json) -->
+<table class="JSON-TO-HTML-TABLE"><thead><tr><th class="key-th">key</th><th class="default-values-th">default values</th></tr></thead><tbody ><tr ><td class="key-td td_text"><code>speed</code></td><td class="default-values-td td_text"><code>2</code></td></tr>
+<tr ><td class="key-td td_text"><code>acceleration</code></td><td class="default-values-td td_text"><code>1.05</code></td></tr>
+<tr ><td class="key-td td_text"><code>friction</code></td><td class="default-values-td td_text"><code>0.95</code></td></tr>
+<tr ><td class="key-td td_text"><code>gravity</code></td><td class="default-values-td td_text"><code>1.5</code></td></tr>
+<tr ><td class="key-td td_text"><code>particles</code></td><td class="default-values-td td_text"><code>50</code></td></tr>
+<tr ><td class="key-td td_text"><code>trace</code></td><td class="default-values-td td_text"><code>3</code></td></tr>
+<tr ><td class="key-td td_text"><code>explosion</code></td><td class="default-values-td td_text"><code>5</code></td></tr>
+<tr ><td class="key-td td_text"><code>autoresize</code></td><td class="default-values-td td_text"><code>true</code></td></tr>
+<tr ><td class="key-td td_text"><code>hue</code></td><td class="default-values-td td_text"><code>{ min: 0, max: 360 }</code></td></tr>
+<tr ><td class="key-td td_text"><code>delay</code></td><td class="default-values-td td_text"><code>{ min: 15, max: 30 }</code></td></tr>
+<tr ><td class="key-td td_text"><code>boundaries</code></td><td class="default-values-td td_text"><code>{ top: 50, bottom: container.clientHeight, left: 50, right: container.clientWidth }</code></td></tr>
+<tr ><td class="key-td td_text"><code>sound</code></td><td class="default-values-td td_text"><code>{ enable: false }</code></td></tr>
+<tr ><td class="key-td td_text"><code>sound.files</code></td><td class="default-values-td td_text"><code>[ '*.mp3', '*.ogg', '*.wav' ]</code></td></tr>
+<tr ><td class="key-td td_text"><code>sound.volume</code></td><td class="default-values-td td_text"><code>{ min: 1, max: 2 }</code></td></tr>
+<tr ><td class="key-td td_text"><code>mouse</code></td><td class="default-values-td td_text"><code>{ click: false, move: false, max: 3 }</code></td></tr>
+<tr ><td class="key-td td_text"><code>brightness</code></td><td class="default-values-td td_text"><code> { min: 50, max: 80 }</code></td></tr>
+<tr ><td class="key-td td_text"><code>brightness.decay</code></td><td class="default-values-td td_text"><code>{ min: 0.015, max: 0.03 }</code></td></tr></tbody></table>
 <!-- MARKDOWN-AUTO-DOCS:END -->

--- a/examples/readme/installation.sh
+++ b/examples/readme/installation.sh
@@ -1,0 +1,5 @@
+# with npm:
+npm install fireworks-js
+
+# or yarn:
+yarn add fireworks-js

--- a/examples/readme/options.json
+++ b/examples/readme/options.json
@@ -1,0 +1,70 @@
+[
+    {
+        "key": "<code>speed</code>",
+        "default values": "<code>2</code>"
+    },
+    {
+        "key": "<code>acceleration</code>",
+        "default values": "<code>1.05</code>"
+    },
+    {
+        "key": "<code>friction</code>",
+        "default values": "<code>0.95</code>"
+    },
+    {
+        "key": "<code>gravity</code>",
+        "default values": "<code>1.5</code>"
+    },
+    {
+        "key": "<code>particles</code>",
+        "default values": "<code>50</code>"
+    },
+    {
+        "key": "<code>trace</code>",
+        "default values": "<code>3</code>"
+    },
+    {
+        "key": "<code>explosion</code>",
+        "default values": "<code>5</code>"
+    },
+    {
+        "key": "<code>autoresize</code>",
+        "default values": "<code>true</code>"
+    },
+    {
+        "key": "<code>hue</code>",
+        "default values": "<code>{ min: 0, max: 360 }</code>"
+    },
+    {
+        "key": "<code>delay</code>",
+        "default values": "<code>{ min: 15, max: 30 }</code>"
+    },
+    {
+        "key": "<code>boundaries</code>",
+        "default values": "<code>{ top: 50, bottom: container.clientHeight, left: 50, right: container.clientWidth }</code>"
+    },
+    {
+        "key": "<code>sound</code>",
+        "default values": "<code>{ enable: false }</code>"
+    },
+    {
+        "key": "<code>sound.files</code>",
+        "default values": "<code>[ '*.mp3', '*.ogg', '*.wav' ]</code>"
+    },
+    {
+        "key": "<code>sound.volume</code>",
+        "default values": "<code>{ min: 1, max: 2 }</code>"
+    },
+    {
+        "key": "<code>mouse</code>",
+        "default values": "<code>{ click: false, move: false, max: 3 }</code>"
+    },
+    {
+        "key": "<code>brightness</code>",
+        "default values": "<code> { min: 50, max: 80 }</code>"
+    },
+    {
+        "key": "<code>brightness.decay</code>",
+        "default values": "<code>{ min: 0.015, max: 0.03 }</code>"
+    }
+]

--- a/examples/readme/usage-react.js
+++ b/examples/readme/usage-react.js
@@ -1,0 +1,18 @@
+import { Fireworks } from 'fireworks-js/dist/react'
+
+export const App = () => {
+  const options = {
+    speed: 3
+  }
+
+  const style = {
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+    position: 'fixed',
+    background: '#000'
+  }
+
+  return <Fireworks options={options} style={style} />
+}

--- a/examples/readme/usage.html
+++ b/examples/readme/usage.html
@@ -1,0 +1,2 @@
+<!-- including in your html page -->
+<script src="https://unpkg.com/fireworks-js@latest/dist/fireworks.js"></script>

--- a/examples/readme/usage.js
+++ b/examples/readme/usage.js
@@ -1,0 +1,22 @@
+// ES6
+import { Fireworks } from 'fireworks-js'
+
+// commonjs
+const { Fireworks } = require('fireworks-js')
+
+// use querySelector or getElementById
+const container = document.querySelector('.fireworks-container')
+
+// default config
+const fireworks = new Fireworks(container, {
+    // options
+})
+
+fireworks.start()
+
+fireworks.pause()
+
+fireworks.clear()
+
+// stop and clear fireworks
+fireworks.stop()


### PR DESCRIPTION
## Problem with updating  Code block or Markdown tables in your README.md 

To make your repo more appealing and, useful you need to provide example code snippets in your README.md. Manually copy and pasting each code snippet or adding a table row in their respective places in your README would be inefficient and time-consuming.

## Solution to this problem:

This problem can be solved using markdown-autodocs GitHub Action that is created by me that automatically generates & updates markdown content (like your README.md) from external or remote files. You need to add markers in your README.md that will tell markdown-autodocs where to insert the code snippet or transform JSON to HTML table.

Markdown Autodocs GitHub action: https://github.com/dineshsonachalam/markdown-autodocs

To test or experiment markdown-autodocs without Github action: https://github.com/dineshsonachalam/markdown-autodocs#local-usage-without-github-action

Please let me know if any changes are required and will be happy to help.

