### PR TITLE
fix(packages/react): canvas will be added twice in react18 development env

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ fireworks.start()
 npm install @fireworks-js/react
 ```
 
+> **Warning**\
+> StrictMode in React 18 will lead useEffect called twice.\
+> Fireworks speed will be broken (in development mode).
+
+
 #### [`@fireworks-js/preact`](https://github.com/crashmax-dev/fireworks-js/tree/master/examples/with-preact)
 
 ```sh

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -14,7 +14,6 @@ const Fireworks = ({ children, options, style }: FireworksProps) => {
   const fireworks = useRef<FireworksJs | null>(null)
 
   useEffect(() => {
-    // React.StrictMode in React18+ will lead useEffect(() => {}, []) called twice.
     if (!fireworks.current) {
       fireworks.current = new FireworksJs(container.current!, options)
     }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -14,7 +14,10 @@ const Fireworks = ({ children, options, style }: FireworksProps) => {
   const fireworks = useRef<FireworksJs | null>(null)
 
   useEffect(() => {
-    fireworks.current = new FireworksJs(container.current!, options)
+    // React.StrictMode in React18+ will lead useEffect(() => {}, []) called twice.
+    if (!fireworks.current) {
+      fireworks.current = new FireworksJs(container.current!, options)
+    }
     fireworks.current.start()
 
     return () => {


### PR DESCRIPTION
@fireworks-js/react: canvas will be added twice in react18 develop env, canvas with fireworks will out of screen. Because `React.StrictMode` in react18 will lead `useEffect(() => {}, [])` called twice.

#### Checklist

- [x] run `pnpm test` and `pnpm format`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/crashmax-dev/fireworks-js/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/crashmax-dev/fireworks-js/blob/master/CODE_OF_CONDUCT.md)
