### PR TITLE
fix: changing options update ordering in Fireworks constructor

### DIFF
--- a/packages/fireworks-js/src/fireworks.ts
+++ b/packages/fireworks-js/src/fireworks.ts
@@ -37,8 +37,8 @@ export class Fireworks {
 
     this.opts = new Options()
 
-    this.updateOptions(options)
     this.createCanvas(this.target)
+    this.updateOptions(options)
 
     this.sound = new Sound(this.opts)
     this.resize = new Resize(


### PR DESCRIPTION
Related issue: #102 

#### Checklist

- [x] run `pnpm format`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/crashmax-dev/fireworks-js/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/crashmax-dev/fireworks-js/blob/master/CODE_OF_CONDUCT.md)
