### PR TITLE
feat(svelte): enable reactivity of options via svelte action

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,3 +1,35 @@
 # @fireworks-js/svelte
 
 > https://github.com/crashmax-dev/fireworks-js
+
+## Installation
+
+```sh
+npm install @fireworks-js/svelte
+```
+
+## Usage
+
+#### [`fireworks-js`](https://github.com/crashmax-dev/fireworks-js/tree/master/examples/with-svelte)
+
+```svelte
+<script lang="ts">
+  import { Fireworks } from '@fireworks-js/svelte'
+  import type { FireworksOptions } from '@fireworks-js/svelte'
+
+  let fw: Fireworks
+  let options: FireworksOptions = {
+    opacity: 0.5
+  }
+
+  function toggleFireworks() {
+    const fireworks = fw.fireworksInstance()
+    if (fireworks.isRunning) {
+      fireworks.waitStop()
+    } else {
+      fireworks.start()
+    }
+  }
+</script>
+<Fireworks bind:this={fw} autostart={false} {options} class="fireworks" />
+```

--- a/packages/svelte/src/lib/fireworks.svelte
+++ b/packages/svelte/src/lib/fireworks.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte'
   import { Fireworks } from 'fireworks-js'
   import type { FireworksOptions } from 'fireworks-js'
 
@@ -9,25 +8,28 @@
   export let style: string = ''
   export let options: FireworksOptions = {}
 
-  let container: HTMLDivElement
   let fireworks: Fireworks
 
   export function fireworksInstance() {
     return fireworks
   }
 
-  onMount(() => {
+  function setup(container:HTMLDivElement, options: FireworksOptions) {
     fireworks = new Fireworks(container, options)
     if (autostart) {
       fireworks.start()
     }
-  })
-
-  onDestroy(() => {
-    fireworks?.stop()
-  })
+    return {
+      update(options: FireworksOptions) {
+        fireworks.updateOptions(options)
+      },
+      destroy() {
+        fireworks.stop()
+      }
+    }
+  }
 </script>
 
-<div bind:this={container} class={className} {style}>
+<div class={className} {style} use:setup={options}>
   <slot></slot>
 </div>


### PR DESCRIPTION
#### Checklist

- [x] run `pnpm format`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/crashmax-dev/fireworks-js/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/crashmax-dev/fireworks-js/blob/master/CODE_OF_CONDUCT.md)

#### Changes
- In order to allow for reactivity of the options object, we used a Svelte action to call the `updateOptions` method any time the options object is changed
- Since the Svelte action directive also supports `onMount` and `onDestroy`, have refactored the original `onMount` and `onDestroy` code into the Svelte action
- Added a condensed extract of the svelte example in [the examples sub-folder](https://github.com/crashmax-dev/fireworks-js/blob/master/examples/with-svelte/src/App.svelte) into the README document to make it easier for someone installing from npm to immediately get going