### PR TITLE
wait until the last minute to load sounds

### DIFF
--- a/packages/fireworks-js/src/fireworks.ts
+++ b/packages/fireworks-js/src/fireworks.ts
@@ -226,6 +226,7 @@ export class Fireworks {
   }
 
   private initTrace(): void {
+    this.sound.init();
     if (this.waitStopRaf) return
 
     const { delay, mouse } = this.opts

--- a/packages/fireworks-js/src/sound.ts
+++ b/packages/fireworks-js/src/sound.ts
@@ -13,7 +13,6 @@ export class Sound {
   private onInit = false
 
   constructor(private readonly options: Options) {
-    this.init()
   }
 
   private get isEnabled() {

--- a/packages/fireworks-js/src/sound.ts
+++ b/packages/fireworks-js/src/sound.ts
@@ -49,6 +49,7 @@ export class Sound {
   }
 
   play(): void {
+    this.init()
     if (this.isEnabled && this.buffers.length) {
       const bufferSource = this.audioContext.createBufferSource()
       const soundBuffer = this.buffers[randomInt(0, this.buffers.length - 1)]!
@@ -62,8 +63,6 @@ export class Sound {
       volume.connect(this.audioContext.destination)
       bufferSource.connect(volume)
       bufferSource.start(0)
-    } else {
-      this.init()
     }
   }
 }


### PR DESCRIPTION
#### Checklist

- [ ] run `pnpm format`
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/crashmax-dev/fireworks-js/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/crashmax-dev/fireworks-js/blob/master/CODE_OF_CONDUCT.md)


Feel free to reject this or change it. It's untested as I can't get the project to build/compile. On my JavaScript version I had to separate out the initialization of audioContext in order for the sound to work on the first firework, like this.

```javascript
  init() {
    if (this.audioContext == null) {
      this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
      this.loadSounds();
    }
    if (!this.onInit && this.isEnabled) {
      this.onInit = true;
    }
  }

```

but it looks like what I committed in typescript will work. 