### PR TITLE
allow users to use their own sound class

### DIFF
--- a/packages/fireworks-js/src/fireworks.ts
+++ b/packages/fireworks-js/src/fireworks.ts
@@ -40,7 +40,7 @@ export class Fireworks {
     this.createCanvas(this.target)
     this.updateOptions(options)
 
-    this.sound = new Sound(this.opts)
+    this.sound = this.opts.soundClass || new Sound(this.opts)
     this.resize = new Resize(
       this.opts,
       this.updateSize.bind(this),


### PR DESCRIPTION
#### Checklist

- [ ] run `pnpm format`
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/crashmax-dev/fireworks-js/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/crashmax-dev/fireworks-js/blob/master/CODE_OF_CONDUCT.md)

This is untested so feel free to reject it. This allows users to override the Sound class, as in the following example.

```javascript
  class CustomFireworksSound extends Sound {
    play() {
      if (this.isEnabled) {
        var soundFiles = this.options.sound.files;
        var randomIndex = Math.floor(Math.random() * soundFiles.length);
        var gainDifference = Math.abs(this.options.sound.volume.min - this.options.sound.volume.max);

        var gain = Math.random() * gainDifference;
        var fileToPlay = soundFiles[randomIndex];
        var audioElement = document.createElement('audio');
        audioElement.src = fileToPlay;
        audioElement.setAttribute('data-gain', gain);
        audioElement.setAttribute('data-allow-simultaneous', 'true');
        playSoundWithEventTracking(audioElement);
        console.log("custom play function");
      }
    }
  }
  fireworksConfig.soundClass = new CustomFireworksSound(fireworksConfig);

```

or if we've wrapped all the Fireworks stuff like this..
```javascript
function fireworksModule() {
   // ... existing code ...
   return {
     Fireworks: Fireworks,
     Sound: Sound
   }
}
```

Then we can use our custom class like this...

```javascript
  const fireworksModuleInstance = fireworksModule();
  const FireworksSoundClass = fireworksModuleInstance.Sound;
  class CustomFireworksSound extends FireworksSoundClass {
    play() {
      // ...etc ...
    }
  }
  fireworksConfig.soundClass = new CustomFireworksSound(fireworksConfig);

```